### PR TITLE
feat: add SinkRotating for rotating log files with automatic pruning

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,10 @@
 export { shunt } from "./shuntly.js";
 export { ShuntlyRecord, ShuntlyRecordData } from "./record.js";
-export { Sink, SinkStream, SinkFile, SinkPipe, SinkMany } from "./sinks.js";
+export {
+  Sink,
+  SinkStream,
+  SinkFile,
+  SinkPipe,
+  SinkRotating,
+  SinkMany,
+} from "./sinks.js";

--- a/test/shuntly.test.ts
+++ b/test/shuntly.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect } from "vitest";
-import { shunt, ShuntlyRecord, Sink, SinkStream } from "../src/index.js";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import {
+  shunt,
+  ShuntlyRecord,
+  Sink,
+  SinkRotating,
+  SinkStream,
+} from "../src/index.js";
 import { Writable } from "stream";
 
 // Helper to capture sink output
@@ -483,5 +492,124 @@ describe("SinkStream", () => {
     expect(parsed.client).toBe("Test");
     expect(parsed.method).toBe("test");
     expect(parsed.durationMs).toBe(42);
+  });
+});
+
+function makeRecord(): ShuntlyRecord {
+  return ShuntlyRecord.build({
+    client: "test.Client",
+    method: "do.thing",
+    request: { a: 1 },
+    response: { b: 2 },
+    durationMs: 5.0,
+  });
+}
+
+describe("SinkRotating", () => {
+  function makeTmpDir(): string {
+    return fs.mkdtempSync(path.join(os.tmpdir(), "shuntly-test-"));
+  }
+
+  function jsonlFiles(dir: string): string[] {
+    return fs.readdirSync(dir).filter((f) => f.endsWith(".jsonl"));
+  }
+
+  it("writes to directory", () => {
+    const dir = makeTmpDir();
+    try {
+      const sink = new SinkRotating(dir);
+      sink.write(makeRecord());
+      sink.close();
+      const files = jsonlFiles(dir);
+      expect(files).toHaveLength(1);
+      const data = JSON.parse(
+        fs.readFileSync(path.join(dir, files[0]), "utf-8").trim(),
+      );
+      expect(data.client).toBe("test.Client");
+    } finally {
+      fs.rmSync(dir, { recursive: true });
+    }
+  });
+
+  it("rotates on maxBytesFile", () => {
+    const dir = makeTmpDir();
+    try {
+      const sink = new SinkRotating(dir, {
+        maxBytesFile: 50,
+        maxBytesDir: 0,
+      });
+      for (let i = 0; i < 5; i++) {
+        sink.write(makeRecord());
+      }
+      sink.close();
+      expect(jsonlFiles(dir).length).toBeGreaterThan(1);
+    } finally {
+      fs.rmSync(dir, { recursive: true });
+    }
+  });
+
+  it("prunes old files", () => {
+    const dir = makeTmpDir();
+    try {
+      const sink = new SinkRotating(dir, {
+        maxBytesFile: 50,
+        maxBytesDir: 500,
+      });
+      for (let i = 0; i < 20; i++) {
+        sink.write(makeRecord());
+      }
+      sink.close();
+      const files = jsonlFiles(dir);
+      const total = files.reduce(
+        (sum, f) => sum + fs.statSync(path.join(dir, f)).size,
+        0,
+      );
+      expect(total).toBeLessThanOrEqual(1500);
+    } finally {
+      fs.rmSync(dir, { recursive: true });
+    }
+  });
+
+  it("creates nested directories", () => {
+    const dir = makeTmpDir();
+    const nested = path.join(dir, "sub", "dir");
+    try {
+      const sink = new SinkRotating(nested);
+      sink.write(makeRecord());
+      sink.close();
+      expect(fs.existsSync(nested)).toBe(true);
+      expect(jsonlFiles(nested)).toHaveLength(1);
+    } finally {
+      fs.rmSync(dir, { recursive: true });
+    }
+  });
+
+  it("close is idempotent", () => {
+    const dir = makeTmpDir();
+    try {
+      const sink = new SinkRotating(dir);
+      sink.write(makeRecord());
+      sink.close();
+      sink.close(); // should not throw
+    } finally {
+      fs.rmSync(dir, { recursive: true });
+    }
+  });
+
+  it("does not prune when disabled", () => {
+    const dir = makeTmpDir();
+    try {
+      const sink = new SinkRotating(dir, {
+        maxBytesFile: 50,
+        maxBytesDir: 0,
+      });
+      for (let i = 0; i < 10; i++) {
+        sink.write(makeRecord());
+      }
+      sink.close();
+      expect(jsonlFiles(dir).length).toBeGreaterThan(1);
+    } finally {
+      fs.rmSync(dir, { recursive: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary

Adds `SinkRotating`, a new sink that writes JSONL records into a directory with automatic file rotation and old-file pruning. Mirrors the implementation merged in shuntly-py (shuntly/shuntly-py#6).

## API

```typescript
import { shunt, SinkRotating } from "shuntly";

const client = shunt(
  new Anthropic(),
  new SinkRotating("/var/log/shuntly/", {
    maxBytesFile: 10_000_000,
    maxBytesDir: 100_000_000,
  })
);
```

## Behavior

- Files named with ISO-8601 timestamps plus milliseconds for uniqueness
- Rotates to a new file when current file exceeds `maxBytesFile`
- Prunes oldest files when total directory size exceeds `maxBytesDir`
- Never deletes the currently active file
- Set `maxBytesDir: 0` to disable pruning
- Directory created automatically including parents
- Pruning only runs on rotation, not every write

## Tests

6 new tests. All 24 tests pass. Build and eslint clean.

Fixes #8